### PR TITLE
Add data retrievability info to the report.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,5 @@ CRITERIA=[{"maxProviderDealPercentage":0.9,"maxDuplicationPercentage":0.2,"maxPe
 ALLOCATION_LABELS=state:Granted,state:DataCapAllocated
 IPINFO_TOKEN=
 RETRIEVAL_BOT_MONGO_URL=
+RETRIEVABILITY_WARNING_THRESHOLD=
+RETRIEVABILITY_RANGE_DAYS=

--- a/src/ManualTrigger.ts
+++ b/src/ManualTrigger.ts
@@ -6,6 +6,10 @@ import * as dotenv from 'dotenv'
 
 export async function manualTrigger (event: APIGatewayProxyEventV2, _: Context): Promise<APIGatewayProxyResult> {
   dotenv.config()
+
+  const retrievabilityWarningIndicator = parseFloat(process.env.RETRIEVABILITY_WARNING_THRESHOLD ?? '0.2')
+  const retrievabilityRange = parseInt(process.env.RETRIEVABILITY_RANGE_DAYS ?? '7')
+
   const issueId = event.queryStringParameters?.issueId
   const repo = event.queryStringParameters?.repo
   const otherAddresses: string[] = event.queryStringParameters?.otherAddresses?.split(' ') ?? []
@@ -62,7 +66,7 @@ export async function manualTrigger (event: APIGatewayProxyEventV2, _: Context):
     maxDuplicationPercentage: 0.20,
     maxPercentageForLowReplica: 0.25,
     lowReplicaThreshold: 3
-  }], otherAddresses)
+  }], otherAddresses, retrievabilityWarningIndicator, retrievabilityRange)
 
   return {
     statusCode: 200,

--- a/src/checker/Types.ts
+++ b/src/checker/Types.ts
@@ -1,3 +1,14 @@
+export interface SparkSuccessRate {
+  miner_id: string
+  success_rate: number
+}
+
+export interface Retrievability {
+  provider_id: string
+  success_rate: number
+  total_deal_size: number
+}
+
 export interface ProviderDistribution {
   provider: string
   total_deal_size: string
@@ -39,6 +50,7 @@ export interface ProviderDistributionRow {
   duplicatePercentage: string
   percentage: string
   location: string
+  retrievability: string
 }
 
 export interface RetrievalRow {

--- a/src/utils/typeGuards.ts
+++ b/src/utils/typeGuards.ts
@@ -1,0 +1,12 @@
+export const isNotEmpty = <TValue>(value: TValue | null | undefined): value is TValue => {
+  return value !== null && value !== undefined
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Constructor<T> = new (...args: any[]) => T
+
+export const isInstanceOf =
+  <TSource, TValue extends TSource>(Type: Constructor<TValue>) =>
+    (value: TSource): value is TValue => {
+      return value instanceof Type
+    }


### PR DESCRIPTION
New features:
1. Flag if any SPs used by client have 0% retrievability rate.
2. Flag if weighted average of retrievability is below threshold.
3. Add column with retrievability rate to SPs table.

Deployment considerations:
* two new env variables are added and should be put in `.env`:
    * `RETRIEVABILITY_WARNING_THRESHOLD` - threshold for which the weighted average flag should be triggered
    * `RETRIEVABILITY_RANGE_DAYS` - how many days of data to fetch from filspark

Sample report generated for these parameters:
```
repo: "filecoin-project/filecoin-plus-large-datasets",
issue: 1889,
id: f02101558
address: f1hbciewgwkj4rizz3nvygoauyuzeynihmzaapvvy.
```

![sample-report](https://github.com/fidlabs/filplus-checker/assets/117277751/23bf0c5f-6f9e-405d-8a34-c0237aecbb65)
