### PR TITLE
Trim whitespace when parsing application issue

### DIFF
--- a/src/ldn-parser-functions/parseAllocator/index.ts
+++ b/src/ldn-parser-functions/parseAllocator/index.ts
@@ -45,7 +45,7 @@ export function parseAllocatorIssue (trimmed) {
       continue
     }
 
-    parsedData[k] = trimmed.match(rg) ? trimmed.match(rg)[0] : null
+    parsedData[k] = trimmed.match(rg) ? trimmed.match(rg)[0].trim() : null
 
     const isCustomRg = /- \[x\] Use Custom Multisig/gi
 


### PR DESCRIPTION
This will prevent issues like this in the future: https://github.com/fidlabs/allocator-tooling/issues/65